### PR TITLE
Fix bug for non-rectangular CellArrays

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,8 +14,8 @@ jobs:
       fail-fast: false
       matrix:
         version:
-          - '1.9'
           - '1.10'
+          - '1.11'
           - 'pre'
         os:
           - ubuntu-latest

--- a/src/cells_CPU.jl
+++ b/src/cells_CPU.jl
@@ -17,7 +17,7 @@ end
 
 Base.@propagate_inbounds @inline function getcell(A::CPUCellArray{SMatrix{Ni, Nj, T, N}, nDim, 1, T}, I::Vararg{Int, nDim}) where {N, Ni, Nj, T, nDim}
     index = Base._to_linear_index(A, I...)
-    linear_SMatrix = LinearIndices((1:Nj, 1:Nj))
+    linear_SMatrix = LinearIndices((1:Ni, 1:Nj))
     SMatrix{Ni, Nj, T}(A.data[1, linear_SMatrix[i, j], index] for i in 1:Ni, j in 1:Nj)
 end
 
@@ -45,7 +45,7 @@ end
         Base.@_inline_meta
         Base.@_propagate_inbounds_meta
         index = Base._to_linear_index(A, I...)
-        linear_SMatrix = LinearIndices((1:$Nj, 1:$Nj))
+        linear_SMatrix = LinearIndices((1:$Ni, 1:$Nj))
         Base.@nexprs $Ni i -> 
             Base.@nexprs $Nj j ->
                 setindex!(A.data, v[i,j], 1, linear_SMatrix[i, j], index)

--- a/src/cells_GPU.jl
+++ b/src/cells_GPU.jl
@@ -7,7 +7,7 @@ end
 
 Base.@propagate_inbounds @inline function getcell(A::CellArray{SMatrix{Ni, Nj, T, N}, nDim, 0, TA}, I::Vararg{Int, nDim}) where {N, Ni, Nj, T, TA, nDim}
     index = Base._to_linear_index(A, I...)
-    linear_SMatrix = LinearIndices((1:Nj, 1:Nj))
+    linear_SMatrix = LinearIndices((1:Ni, 1:Nj))
     SMatrix{Ni, Nj, T}(A.data[index, linear_SMatrix[i, j], 1] for i in 1:Ni, j in 1:Nj)
 end
 
@@ -26,7 +26,7 @@ end
         Base.@_inline_meta
         Base.@_propagate_inbounds_meta
         index = Base._to_linear_index(A, I...)
-        linear_SMatrix = LinearIndices((1:$Nj, 1:$Nj))
+        linear_SMatrix = LinearIndices((1:$Ni, 1:$Nj))
         Base.@nexprs $Ni i -> 
             Base.@nexprs $Nj j ->
                 setindex!(A.data, v[i,j], index, linear_SMatrix[i, j], 1)

--- a/src/indices_CPU.jl
+++ b/src/indices_CPU.jl
@@ -18,7 +18,7 @@ end
 
 Base.@propagate_inbounds @inline function getcellindex(A::CPUCellArray{SMatrix{Ni, Nj, T, N}, nDim, 1, T}, cellᵢ::Int, cellⱼ::Int, I::Vararg{Int, nDim}) where {N, Ni, Nj, T, nDim}
     index = Base._to_linear_index(A, I...)
-    linear_SMatrix = LinearIndices((1:Nj, 1:Nj))
+    linear_SMatrix = LinearIndices((1:Ni, 1:Nj))
     A.data[1, linear_SMatrix[cellᵢ, cellⱼ], index]
 end
 
@@ -43,6 +43,6 @@ end
 
 Base.@propagate_inbounds function setcellindex!(A::CPUCellArray{SMatrix{Ni, Nj, T, N}, nDim, 1, T}, v::T, cellᵢ::Int, cellⱼ::Int, I::Vararg{Int, nDim}) where {N, Ni, Nj, nDim, T}
     index = Base._to_linear_index(A, I...)
-    linear_SMatrix = LinearIndices((1:Nj, 1:Nj))
+    linear_SMatrix = LinearIndices((1:Ni, 1:Nj))
     setindex!(A.data, v, 1, linear_SMatrix[cellᵢ, cellⱼ], index)
 end

--- a/src/indices_GPU.jl
+++ b/src/indices_GPU.jl
@@ -6,7 +6,7 @@ end
 
 Base.@propagate_inbounds @inline function getcellindex(A::CellArray{SMatrix{Ni, Nj, T, N}, nDim, 0, TA}, cellᵢ::Int, cellⱼ::Int, I::Vararg{Int, nDim}) where {N, Ni, Nj, T, TA, nDim}
     index = Base._to_linear_index(A, I...)
-    linear_SMatrix = LinearIndices((1:Nj, 1:Nj))
+    linear_SMatrix = LinearIndices((1:Ni, 1:Nj))
     A.data[index, linear_SMatrix[cellᵢ, cellⱼ], 1]
 end
 
@@ -18,6 +18,6 @@ end
 
 Base.@propagate_inbounds function setcellindex!(A::CellArray{SMatrix{Ni, Nj, T, N}, nDim, 0, TA}, v::Real, cellᵢ::Int, cellⱼ::Int, I::Vararg{Int, nDim}) where {N, Ni, Nj, nDim, T, TA}
     index = Base._to_linear_index(A, I...)
-    linear_SMatrix = LinearIndices((1:Nj, 1:Nj))
+    linear_SMatrix = LinearIndices((1:Ni, 1:Nj))
     setindex!(A.data, v, index, linear_SMatrix[cellᵢ, cellⱼ], 1)
 end

--- a/test/test_cells.jl
+++ b/test/test_cells.jl
@@ -12,7 +12,16 @@
         end
 
         @testset "SMatrix" begin
+            # rectangular matrix
             A = @rand(ni..., celldims=(2,2))
+            c = A[2,2]
+            setcell!(A, c, 1, 1)
+
+            @test A[1,1] == A[2,2]
+            @test A[1,1] == getcell(A,2,2)
+
+            # non-rectangular matrix
+            A = @rand(ni..., celldims=(6,3))
             c = A[2,2]
             setcell!(A, c, 1, 1)
 
@@ -35,6 +44,13 @@
 
         @testset "SMatrix" begin
             A = @rand(ni..., celldims=(2,2))
+            c = A[2,2,2]
+            setcell!(A, c, 1, 1, 1)
+
+            @test A[1,1,1] == A[2,2,2]
+            @test A[1,1,1] == getcell(A,2,2,2)
+
+            A = @rand(ni..., celldims=(6,3))
             c = A[2,2,2]
             setcell!(A, c, 1, 1, 1)
 

--- a/test/test_indexing.jl
+++ b/test/test_indexing.jl
@@ -18,6 +18,13 @@
             
             @index A[2, 2, 1, 1] = 5.1
             @test 5.1 == @index A[2, 2, 1, 1] 
+
+            A = @rand(ni..., celldims=(6, 3));
+            setcellindex!(A, 1.2, 2, 2, 1, 1)
+            @test getcellindex(A, 2, 2, 1, 1) == 1.2
+            
+            @index A[2, 2, 1, 1] = 5.1
+            @test 5.1 == @index A[2, 2, 1, 1] 
         end
     end
 
@@ -35,6 +42,13 @@
 
         @testset "SMatrix" begin
             A = @rand(ni..., celldims=(2,2));
+            setcellindex!(A, 1.2, 2, 2, 1, 1, 1)
+            @test getcellindex(A, 2, 2, 1, 1, 1) == 1.2
+            
+            @index A[2, 2, 1, 1, 1] = 5.1
+            @test 5.1 == @index A[2, 2, 1, 1, 1] 
+
+            A = @rand(ni..., celldims=(6,3));
             setcellindex!(A, 1.2, 2, 2, 1, 1, 1)
             @test getcellindex(A, 2, 2, 1, 1, 1) == 1.2
             


### PR DESCRIPTION
Fixes bug in both `@cell` and `@index` macros for non-rectangular `CellArray`s.